### PR TITLE
import from react instead of react-native

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,8 @@
-'use strict';
+import React from 'react';
+import { View, Animated, PanResponder } from 'react-native';
+import styles from './styles';
 
-var React = require('react-native');
-var {
-  View,
-  Animated,
-  PanResponder
-} = React;
-var styles = require('./styles');
-
-var MaterialButton = React.createClass({
+const MaterialButton = React.createClass({
   getDefaultProps() {
     return {
       withRipple: true,
@@ -220,4 +214,4 @@ var MaterialButton = React.createClass({
   }
 });
 
-module.exports = MaterialButton;
+export default MaterialButton;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-button",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Customizable material style button",
   "main": "index.js",
   "scripts": {

--- a/styles.js
+++ b/styles.js
@@ -1,6 +1,6 @@
-var React = require('react-native');
+import { StyleSheet } from 'react-native';
 
-module.exports = React.StyleSheet.create({
+const styles = StyleSheet.create({
   rippleContainer: {
     backgroundColor: 'transparent',
     overflow: 'hidden',
@@ -21,3 +21,5 @@ module.exports = React.StyleSheet.create({
     overflow: 'visible',
   }
 });
+
+export default styles;


### PR DESCRIPTION
As of `react-native` 0.25, `React` must be required/imported from `react`directly otherwise it breaks.
