### PR TITLE
Update for newer react-native versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,12 @@ const MaterialButton = React.createClass({
     });
   },
 
+  componentWillUnmount() {
+    if (this.liftInterval) {
+      clearInterval(this.liftInterval);
+    }
+  },
+
   liftUp() {
     Animated.parallel([
       Animated.timing(this.state.shadowRadius, {

--- a/index.js
+++ b/index.js
@@ -1,14 +1,8 @@
-'use strict';
+import React from 'react';
+import { View, Animated, PanResponder } from 'react-native';
+import styles from './styles';
 
-var React = require('react-native');
-var {
-  View,
-  Animated,
-  PanResponder
-} = React;
-var styles = require('./styles');
-
-var MaterialButton = React.createClass({
+const MaterialButton = React.createClass({
   getDefaultProps() {
     return {
       withRipple: true,
@@ -219,4 +213,4 @@ var MaterialButton = React.createClass({
   }
 });
 
-module.exports = MaterialButton;
+export default MaterialButton;

--- a/index.js
+++ b/index.js
@@ -165,7 +165,6 @@ var MaterialButton = React.createClass({
 
   onLayout(e) {
     var { x, y, width, height } = e.nativeEvent.layout;
-    console.log(x, y, width, height);
     this.setState({
       top: y,
       left: x,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-button",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "Customizable material style button",
   "main": "index.js",
   "scripts": {
@@ -29,6 +29,6 @@
   },
   "homepage": "https://github.com/recr0ns/react-native-material-button",
   "peerDependencies": {
-    "react-native": ">= 0.9.0"
+    "react-native": ">= 0.25.0"
   }
 }

--- a/styles.js
+++ b/styles.js
@@ -1,6 +1,6 @@
-var React = require('react-native');
+import { StyleSheet } from 'react-native';
 
-module.exports = React.StyleSheet.create({
+const styles = StyleSheet.create({
   rippleContainer: {
     backgroundColor: 'transparent',
     overflow: 'hidden',
@@ -21,3 +21,5 @@ module.exports = React.StyleSheet.create({
     overflow: 'visible',
   }
 });
+
+export default styles;


### PR DESCRIPTION
This PR removes an unnecessary console.log, imports `react` from `react` instead of `react-native`, and bumps the library version to `1.0.0` as this is a breaking change, and require `react-native` v0.25 or newer.
